### PR TITLE
컴파일 옵션을 변경하고 polyfill을 추가합니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.DS_Store
 .rpt2_cache
+.vscode
 coverage
 dist
 doc

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "typedoc": "typedoc --out doc src",
     "build": "yarn run typedoc && rm -rf dist && rollup -c",
-    "lint": "tslint --project tsconfig.lint.json",
+    "lint": "tslint --project tsconfig.json",
     "pretest": "yarn run lint",
     "test": "jest --coverage",
     "prepublishOnly": "yarn run test && yarn run build"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,9 @@ export default {
     format: 'cjs',
   },
   plugins: [
-    typescript()
+    typescript({
+      tsconfig: 'tsconfig.prod.json',
+      typescript: require('typescript'),
+    })
   ]
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,8 @@
 import './polyfill'
 
+export { default as PitchSystem } from './pitch-system'
+export { default as TuningSystem } from './tuning-system'
+
 export function isValidPitch(pitch: string): boolean {
   return /^[A-G](#|b)?[0-9]?$/.test(pitch)
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+import './polyfill'
+
 export function isValidPitch(pitch: string): boolean {
   return /^[A-G](#|b)?[0-9]?$/.test(pitch)
 }

--- a/src/pitch-system.ts
+++ b/src/pitch-system.ts
@@ -2,7 +2,7 @@ import { ColoradoError } from './util'
 
 import TuningSystem, { defaultTuningSystem } from './tuning-system'
 
-interface IConstructorOpt {
+export interface IConstructorOpt {
   concertPitch?: number,
   tuningSystem?: TuningSystem,
 }

--- a/src/polyfill.spec.ts
+++ b/src/polyfill.spec.ts
@@ -1,0 +1,14 @@
+import './polyfill'
+
+describe('Polyfill', () => {
+  describe('Number', () => {
+    it('should have `isInteger`', () => {
+      expect(Number.isInteger(3)).toBe(true)
+      expect(Number.isInteger(2.3)).toBe(false)
+      expect(Number.isInteger(NaN)).toBe(false)
+      expect(Number.isInteger('0')).toBe(false)
+      expect(Number.isInteger('123')).toBe(false)
+      expect(Number.isInteger({foo: 'bar'})).toBe(false)
+    })
+  })
+})

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -1,0 +1,14 @@
+/* tslint:disable:interface-name */
+
+/* tslint:disable-next-line:max-line-length */
+/* https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger */
+
+interface NumberConstructor {
+  isInteger(value: any): boolean
+}
+
+Number.isInteger = Number.isInteger || ((value) => {
+  return typeof value === 'number' &&
+    isFinite(value) &&
+    Math.floor(value) === value
+})

--- a/src/tuning-system.ts
+++ b/src/tuning-system.ts
@@ -1,6 +1,6 @@
 import { ColoradoError } from './util'
 
-interface IConstructorOpt {
+export interface IConstructorOpt {
   isEqualTemperament?: boolean,
   ratiosToConcertPitch?: number[],
   numberOfTones?: number,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "rootDir": "src",
         "outDir": "dist"
     },
-    "files": [
-        "src/main.ts"
+    "include": [
+        "src"
     ]
 }

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -1,6 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "include": [
-        "src/**/*.spec.ts"
-    ]
-}

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "include": [],
+    "files": [
+        "src/main.ts"
+    ]
+}


### PR DESCRIPTION
# 개요
- VSCode에서 `tsconfig.json`만 바라보고 있어서, 여기에 기존에 `include`되어 있지 않았던 파일들(즉, `main.ts`를 제외한 다른 모든 파일)은 IDE가 `tsconfig.json`에 주어진 설정대로 검사하고 있지 않았으며, 정상적인 경우 빌드되지 않았을 것들도 통과되고 있었습니다.
- 따라서 `tsconfig.json`을 `tsconfig.json`과 `tsconfig.prod.json`으로 나누고, 후자만 빌드에 사용하며, 실제로 프로젝트 전반에 공유되는 내용은 전자에 넣었습니다. 이러면 본 설정과 `include`만 달리 하던 `tsconfig.lint.json`이 의미가 없어지므로 이 파일은 삭제했습니다.
- 위와 같이 작업하면 기존에 발견되지 않았던 컴파일 에러가 발생하는데, 그 중 하나가 `isInteger`가 컴파일 타겟인 ES5에 정의되지 않아 발생하는 컴파일 에러입니다. 따라서 `isInteger`를 polyfill로 정의해 사용합니다.

하려던 건 한 줄도 못 짜고 컨피그만 잔뜩 건드렸네요. 허탈. 😢 