### PR TITLE
SPN으로부터 Pitch class를 생성하는 방법을 추가합니다.

### DIFF
--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -1,16 +1,5 @@
-import { isValidPitch } from './main'
-
-describe('isValidPitch', () => {
-  it('should return true for correct pitch notations', () => {
-    expect(isValidPitch('C')).toBe(true)
-    expect(isValidPitch('D#')).toBe(true)
-    expect(isValidPitch('Gb')).toBe(true)
-    expect(isValidPitch('B3')).toBe(true)
-    expect(isValidPitch('Ab4')).toBe(true)
-  })
-
-  it('should return false for invalid pitch notations', () => {
-    expect(isValidPitch('H')).toBe(false)
-    expect(isValidPitch('c')).toBe(false)
+describe('Dummy', () => {
+  it ('is a dummy test', () => {
+    expect(true).toBe(true)
   })
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,3 @@ import './polyfill'
 export { default as Pitch } from './pitch'
 export { default as PitchSystem } from './pitch-system'
 export { default as TuningSystem } from './tuning-system'
-
-export function isValidPitch(pitch: string): boolean {
-  return /^[A-G](#|b)?[0-9]?$/.test(pitch)
-}

--- a/src/pitch.spec.ts
+++ b/src/pitch.spec.ts
@@ -28,3 +28,45 @@ describe('Pitch.isValidSPN', () => {
     expect(Pitch.isValidSPN('F#003')).toBe(false)
   })
 })
+
+describe('Pitch.fromSPN', () => {
+  it('should create correct `Pitch` object for correct pitch notations', () => {
+    expect(Pitch.fromSPN('Cb5').height).toBe(2)
+    expect(Pitch.fromSPN('C5').height).toBe(3)
+    expect(Pitch.fromSPN('C#-3').height).toBe(-92)
+    expect(Pitch.fromSPN('Db-3').height).toBe(-92)
+    expect(Pitch.fromSPN('D5').height).toBe(5)
+    expect(Pitch.fromSPN('D#10').height).toBe(66)
+    expect(Pitch.fromSPN('Eb10').height).toBe(66)
+    expect(Pitch.fromSPN('E5').height).toBe(7)
+    expect(Pitch.fromSPN('E#6').height).toBe(20)
+    expect(Pitch.fromSPN('Fb5').height).toBe(7)
+    expect(Pitch.fromSPN('F6').height).toBe(20)
+    expect(Pitch.fromSPN('F#4').height).toBe(-3)
+    expect(Pitch.fromSPN('Gb4').height).toBe(-3)
+    expect(Pitch.fromSPN('G5').height).toBe(10)
+    expect(Pitch.fromSPN('G#0').height).toBe(-49)
+    expect(Pitch.fromSPN('Ab0').height).toBe(-49)
+    expect(Pitch.fromSPN('A4').height).toBe(0)
+    expect(Pitch.fromSPN('A#1').height).toBe(-35)
+    expect(Pitch.fromSPN('Bb1').height).toBe(-35)
+    expect(Pitch.fromSPN('B4').height).toBe(2)
+    expect(Pitch.fromSPN('B#4').height).toBe(3)
+  })
+
+  it('should throw an error for invalid pitch notations', () => {
+    const errMsg = 'Valid SPN should be given'
+    expect(() => {
+      Pitch.fromSPN('C')
+    }).toThrow(errMsg)
+    expect(() => {
+      Pitch.fromSPN('c')
+    }).toThrow(errMsg)
+    expect(() => {
+      Pitch.fromSPN('C3.5')
+    }).toThrow(errMsg)
+    expect(() => {
+      Pitch.fromSPN('F#003')
+    }).toThrow(errMsg)
+  })
+})

--- a/src/pitch.spec.ts
+++ b/src/pitch.spec.ts
@@ -22,6 +22,7 @@ describe('Pitch.isValidSPN', () => {
     expect(Pitch.isValidSPN('Gb')).toBe(false)
     expect(Pitch.isValidSPN('H')).toBe(false)
     expect(Pitch.isValidSPN('c')).toBe(false)
+    expect(Pitch.isValidSPN('d3')).toBe(false)
     expect(Pitch.isValidSPN('X4')).toBe(false)
     expect(Pitch.isValidSPN('4')).toBe(false)
     expect(Pitch.isValidSPN('Gk4')).toBe(false)

--- a/src/pitch.spec.ts
+++ b/src/pitch.spec.ts
@@ -7,3 +7,24 @@ describe('Pitch', () => {
     expect(pitch.height).toBe(3)
   })
 })
+
+describe('Pitch.isValidSPN', () => {
+  it('should return true for correct pitch notations', () => {
+    expect(Pitch.isValidSPN('C#-1')).toBe(true)
+    expect(Pitch.isValidSPN('B3')).toBe(true)
+    expect(Pitch.isValidSPN('Ab4')).toBe(true)
+    expect(Pitch.isValidSPN('F#-13')).toBe(true)
+  })
+
+  it('should return false for invalid pitch notations', () => {
+    expect(Pitch.isValidSPN('C')).toBe(false)
+    expect(Pitch.isValidSPN('D#')).toBe(false)
+    expect(Pitch.isValidSPN('Gb')).toBe(false)
+    expect(Pitch.isValidSPN('H')).toBe(false)
+    expect(Pitch.isValidSPN('c')).toBe(false)
+    expect(Pitch.isValidSPN('X4')).toBe(false)
+    expect(Pitch.isValidSPN('4')).toBe(false)
+    expect(Pitch.isValidSPN('Gk4')).toBe(false)
+    expect(Pitch.isValidSPN('F#003')).toBe(false)
+  })
+})

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -1,29 +1,31 @@
 import { ColoradoError, integer } from './util'
 
 const spnRegex = /^([A-G](#|b)?)(-?([1-9][0-9]+|[0-9]))$/
+/* tslint:disable:object-literal-sort-keys */
 const heightOfPitchClass = {
-  'A': 0,
-  'A#': 1,
-  'Ab': -1,
-  'B': 2,
-  'B#': 3,
-  'Bb': 1,
+  'Cb': -10,
   'C': -9,
   'C#': -8,
-  'Cb': -10,
+  'Db': -8,
   'D': -7,
   'D#': -6,
-  'Db': -8,
+  'Eb': -6,
   'E': -5,
   'E#': -4,
-  'Eb': -6,
+  'Fb': -5,
   'F': -4,
   'F#': -3,
-  'Fb': -5,
+  'Gb': -3,
   'G': -2,
   'G#': -1,
-  'Gb': -3,
+  'Ab': -1,
+  'A': 0,
+  'A#': 1,
+  'Bb': 1,
+  'B': 2,
+  'B#': 3,
 }
+/* tslint:enable:object-literal-sort-keys */
 
 export default class Pitch {
   public static isValidSPN(spn: string): boolean {

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -1,6 +1,10 @@
 import { integer } from './util'
 
 export default class Pitch {
+  public static isValidSPN(spn: string): boolean {
+    return /^[A-G](#|b)?-?([1-9][0-9]+|[0-9])$/.test(spn)
+  }
+
   @integer
   public height: number
 

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -1,43 +1,45 @@
 import { ColoradoError, integer } from './util'
 
+const spnRegex = /^([A-G](#|b)?)(-?([1-9][0-9]+|[0-9]))$/
+const heightOfPitchClass = {
+  'A': 0,
+  'A#': 1,
+  'Ab': -1,
+  'B': 2,
+  'B#': 3,
+  'Bb': 1,
+  'C': -9,
+  'C#': -8,
+  'Cb': -10,
+  'D': -7,
+  'D#': -6,
+  'Db': -8,
+  'E': -5,
+  'E#': -4,
+  'Eb': -6,
+  'F': -4,
+  'F#': -3,
+  'Fb': -5,
+  'G': -2,
+  'G#': -1,
+  'Gb': -3,
+}
+
 export default class Pitch {
   public static isValidSPN(spn: string): boolean {
-    return /^[A-G](#|b)?-?([1-9][0-9]+|[0-9])$/.test(spn)
+    return spnRegex.test(spn)
   }
 
   public static fromSPN(spn: string): Pitch {
     if (!Pitch.isValidSPN(spn)) {
       throw new ColoradoError('Valid SPN should be given')
     }
-    const spnRegex = /^([A-G](#|b)?)(-?([1-9][0-9]+|[0-9]))$/
     const match = spnRegex.exec(spn)
-    let height: number
-    switch (match[1]) {
-      // A4 is height 0
-      case 'A': height = 0; break
-      case 'A#':
-      case 'Bb': height = 1; break
-      case 'B': height = 2; break
-      case 'B#': height = 3; break
-      case 'Cb': height = -10; break
-      case 'C': height = -9; break
-      case 'C#':
-      case 'Db': height = -8; break
-      case 'D': height = -7; break
-      case 'D#':
-      case 'Eb': height = -6; break
-      case 'E':
-      case 'Fb': height = -5; break
-      case 'E#':
-      case 'F': height = -4; break
-      case 'F#':
-      case 'Gb': height = -3; break
-      case 'G': height = -2; break
-      case 'G#':
-      case 'Ab': height = -1; break
-    }
-    // Parse octave notation
-    height = height + 12 * (parseInt(match[3], 10) - 4)
+    const pitchClass = match[1]
+    const octave = match[3]
+
+    const octaveOffset = parseInt(octave, 10) - 4
+    const height = heightOfPitchClass[pitchClass] + 12 * octaveOffset
     return new Pitch(height)
   }
 

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -1,8 +1,44 @@
-import { integer } from './util'
+import { ColoradoError, integer } from './util'
 
 export default class Pitch {
   public static isValidSPN(spn: string): boolean {
     return /^[A-G](#|b)?-?([1-9][0-9]+|[0-9])$/.test(spn)
+  }
+
+  public static fromSPN(spn: string): Pitch {
+    if (!Pitch.isValidSPN(spn)) {
+      throw new ColoradoError('Valid SPN should be given')
+    }
+    const spnRegex = /^([A-G](#|b)?)(-?([1-9][0-9]+|[0-9]))$/
+    const match = spnRegex.exec(spn)
+    let height: number
+    switch (match[1]) {
+      // A4 is height 0
+      case 'A': height = 0; break
+      case 'A#':
+      case 'Bb': height = 1; break
+      case 'B': height = 2; break
+      case 'B#': height = 3; break
+      case 'Cb': height = -10; break
+      case 'C': height = -9; break
+      case 'C#':
+      case 'Db': height = -8; break
+      case 'D': height = -7; break
+      case 'D#':
+      case 'Eb': height = -6; break
+      case 'E':
+      case 'Fb': height = -5; break
+      case 'E#':
+      case 'F': height = -4; break
+      case 'F#':
+      case 'Gb': height = -3; break
+      case 'G': height = -2; break
+      case 'G#':
+      case 'Ab': height = -1; break
+    }
+    // Parse octave notation
+    height = height + 12 * (parseInt(match[3], 10) - 4)
+    return new Pitch(height)
   }
 
   @integer

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -30,6 +30,13 @@ export default class Pitch {
     return spnRegex.test(spn)
   }
 
+  /*
+  Be careful that the `Pitch` object returned by this `fromSPN` is meaningful
+  only if the current tuning system is 12 tone equal temperament (12-TET) or
+  12 tone just intonation. Check the following link for more details about
+  Scientific Pitch Notation (SPN).
+  https://en.wikipedia.org/wiki/Scientific_pitch_notation
+  */
   public static fromSPN(spn: string): Pitch {
     if (!Pitch.isValidSPN(spn)) {
       throw new ColoradoError('Valid SPN should be given')


### PR DESCRIPTION
이슈 #9 와 관련된 PR입니다.

당시 해당 이슈에서, `new Pitch('A4')`의 형태를 갖는 것이 낫다고 생각했는데, JS의 특징상 생성자 오버로딩이 쉽지 않아서 static factory method인 `fromSPN`을 만드는 쪽으로 방향을 선회했습니다.

본 PR의 변경 사항은 다음과 같습니다.
  - `Pitch` class에 static helper method인 `isValidSPN`을 추가했습니다.
      - 해당 함수는 인자로 받은 string이 SPN에 적합한 form인지 확인하고 그 결과를 boolean으로 return합니다. 주의해야 할 점은, `C4`는 SPN이지만 `C`는 SPN이 아니라는 것입니다. (Wikipedia의 [SPN 문서](https://en.wikipedia.org/wiki/Scientific_pitch_notation) 참고)
  - `Pitch` class에 static factory method인 `fromSPN`을 추가했습니다.
      - 해당 함수는 인자로 받은 SPN 값을 파싱하여 적절한 height를 지닌 `Pitch` object를 리턴합니다. 인자로 주어진 것이 적합하지 않으면 에러를 던집니다.

비고
  - SPN과 관련된 모든 내용은 12 tone just intonation 혹은 12 tone equal temperament가 가정되었을때만 유의미합니다. 그러나 `Pitch` object는 그저 단순히 '해당 pitch가 concert pitch를 기준으로 몇 단위 음에 위치하는가'의 정보만을 기록하기 때문에 tuning system과는 완전히 독립적입니다. 이는 곧 12-TET나 12-TJI (편의상 이렇게 기록하겠습니다) 가 아닌 Tuning system상에서 SPN을 이용해 생성한 `Pitch` object를 사용할 수 있다는 뜻도 되는데요, 이는 라이브러리에서 검사를 해 거르는 것이 아닌, 유저가 주의해서 사용해야 하는 부분으로 남겨둬야 할까요?
   - 본 PR에서 `isValidSPN`을 추가했기 때문에 이제 `main.ts`에 있는 `isValidPitch`와 관련 테스트를 지워야합니다.