### PR TITLE
[#11] polyfill을 테스트 가능하게 합니다.

### DIFF
--- a/src/polyfill.spec.ts
+++ b/src/polyfill.spec.ts
@@ -1,14 +1,14 @@
-import './polyfill'
+import { isInteger } from './polyfill'
 
 describe('Polyfill', () => {
   describe('Number', () => {
     it('should have `isInteger`', () => {
-      expect(Number.isInteger(3)).toBe(true)
-      expect(Number.isInteger(2.3)).toBe(false)
-      expect(Number.isInteger(NaN)).toBe(false)
-      expect(Number.isInteger('0')).toBe(false)
-      expect(Number.isInteger('123')).toBe(false)
-      expect(Number.isInteger({foo: 'bar'})).toBe(false)
+      expect(isInteger(3)).toBe(true)
+      expect(isInteger(2.3)).toBe(false)
+      expect(isInteger(NaN)).toBe(false)
+      expect(isInteger('0')).toBe(false)
+      expect(isInteger('123')).toBe(false)
+      expect(isInteger({foo: 'bar'})).toBe(false)
     })
   })
 })

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -3,12 +3,16 @@
 /* tslint:disable-next-line:max-line-length */
 /* https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger */
 
-interface NumberConstructor {
-  isInteger(value: any): boolean
+declare global {
+  interface NumberConstructor {
+    isInteger(value: any): boolean
+  }
 }
 
-Number.isInteger = Number.isInteger || ((value) => {
+export function isInteger(value) {
   return typeof value === 'number' &&
     isFinite(value) &&
     Math.floor(value) === value
-})
+}
+
+Number.isInteger = Number.isInteger || isInteger


### PR DESCRIPTION
polyfill로 들어가는 각 함수를 떼어내 테스트합니다.

polyfill을 주입하는 라인 자체에 대한 테스트는 작성하지 않는 편이 좋겠습니다. 단순히 커버리지 수치만을 위해 trivial한 라인까지 프로젝트 테스트 환경 구조 자체를 트윅해가며 테스트를 작성하는 것은 배보다 배꼽이 더 커지는 케이스인 것 같습니다.