### PR TITLE
import를 소스 루트에 대한 것으로 변경합니다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
       "**/*.spec.ts"
     ],
     "mapCoverage": true,
-    "setupFiles": ["<rootDir>/src/polyfill.ts"]
+    "setupFiles": ["<rootDir>/src/polyfill.ts"],
+    "moduleNameMapper": {
+      "@/(.*)$": "<rootDir>/src/$1"
+    }
   },
   "types": "dist/main.d.ts",
   "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,12 @@ export default {
   },
   plugins: [
     typescript({
-      tsconfig: 'tsconfig.prod.json',
+      tsconfig: 'tsconfig.json',
+      tsconfigOverride: {
+        include: [
+          'src/main.ts',
+        ],
+      },
       typescript: require('typescript'),
     })
   ]

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
-import './polyfill'
+import '@/polyfill'
 
-export { default as Pitch } from './pitch'
-export { default as PitchSystem } from './pitch-system'
-export { default as TuningSystem } from './tuning-system'
+export { default as Pitch } from '@/pitch'
+export { default as PitchSystem } from '@/pitch-system'
+export { default as TuningSystem } from '@/tuning-system'

--- a/src/pitch-system.spec.ts
+++ b/src/pitch-system.spec.ts
@@ -1,6 +1,6 @@
-import Pitch from './pitch'
-import PitchSystem, { defaultPitchSystem } from './pitch-system'
-import TuningSystem, { defaultTuningSystem } from './tuning-system'
+import Pitch from '@/pitch'
+import PitchSystem, { defaultPitchSystem } from '@/pitch-system'
+import TuningSystem, { defaultTuningSystem } from '@/tuning-system'
 
 describe('PitchSystem', () => {
   describe('constructor', () => {

--- a/src/pitch-system.ts
+++ b/src/pitch-system.ts
@@ -1,7 +1,7 @@
-import { ColoradoError } from './util'
+import { ColoradoError } from '@/util'
 
-import Pitch from './pitch'
-import TuningSystem, { defaultTuningSystem } from './tuning-system'
+import Pitch from '@/pitch'
+import TuningSystem, { defaultTuningSystem } from '@/tuning-system'
 
 export interface IConstructorOpt {
   concertPitch?: number,

--- a/src/pitch.spec.ts
+++ b/src/pitch.spec.ts
@@ -1,4 +1,4 @@
-import Pitch from './pitch'
+import Pitch from '@/pitch'
 
 describe('Pitch', () => {
   it('should be initialized with height', () => {

--- a/src/pitch.ts
+++ b/src/pitch.ts
@@ -1,4 +1,4 @@
-import { ColoradoError, integer } from './util'
+import { ColoradoError, integer } from '@/util'
 
 const spnRegex = /^([A-G](#|b)?)(-?([1-9][0-9]+|[0-9]))$/
 /* tslint:disable:object-literal-sort-keys */

--- a/src/polyfill.spec.ts
+++ b/src/polyfill.spec.ts
@@ -1,4 +1,4 @@
-import { isInteger } from './polyfill'
+import { isInteger } from '@/polyfill'
 
 describe('Polyfill', () => {
   describe('Number', () => {

--- a/src/tuning-system.spec.ts
+++ b/src/tuning-system.spec.ts
@@ -1,7 +1,7 @@
-import { ColoradoError } from './util'
+import { ColoradoError } from '@/util'
 
-import Pitch from './pitch'
-import TuningSystem, { defaultTuningSystem } from './tuning-system'
+import Pitch from '@/pitch'
+import TuningSystem, { defaultTuningSystem } from '@/tuning-system'
 
 describe('TuningSystem', () => {
   describe('constructor', () => {

--- a/src/tuning-system.ts
+++ b/src/tuning-system.ts
@@ -1,6 +1,6 @@
-import { ColoradoError } from './util'
+import { ColoradoError } from '@/util'
 
-import Pitch from './pitch'
+import Pitch from '@/pitch'
 
 export interface IConstructorOpt {
   isEqualTemperament?: boolean,

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -1,4 +1,4 @@
-import { integer } from './util'
+import { integer } from '@/util'
 
 describe('integer', () => {
   class Test {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,13 @@
         "declaration": true,
         "rootDir": "src",
         "outDir": "dist",
-        "experimentalDecorators": true
+        "experimentalDecorators": true,
+        "baseUrl": "./",
+        "paths": {
+            "@/*": ["src/*"]
+        }
     },
     "include": [
-        "src"
+        "src/*"
     ]
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,7 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "include": [],
-    "files": [
-        "src/main.ts"
-    ]
-}


### PR DESCRIPTION
제곧내.

소스 루트(`./src`)를 `@`로 alias를 취하고 나니 `rollup-plugin-typescript2`가 `tsconfig.prod.json`의 `extends`키를 비정상적으로 핸들링하는 듯 하더군요. `main.ts`에서 `import`하는 모든 파일을 plain JS로 취급하는 것처럼 보였습니다.

따라서 그냥 `tsconfig.json`만 남기고, 다행히 플러그인에 [설정을 덮어씌우는 옵션](https://github.com/ezolenko/rollup-plugin-typescript2#plugin-options)이 있어서 `include`키만 덮어씌웠습니다. 이렇게라도 하니까 정상적으로 돌긴 해서 다행이네요.